### PR TITLE
Adding source and target

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,8 +10,8 @@
         <artifactId>maven-compiler-plugin</artifactId>
         <version>3.1</version>
         <configuration>
-          <source/>
-          <target/>
+          <source>1.7</source>
+          <target>1.7</target>
         </configuration>
       </plugin>
     </plugins>


### PR DESCRIPTION
Specifying Source and Target Version For Java JDK was failing earlier because of none version specified on MAC OS X Sierra

Throwing errors while building in mac os x 10.12.5
 binary literals are not supported in -source 1.5
  (use -source 7 or higher to enable binary literals)
