### PR TITLE
Two exceptions caused hang/infinite loop in QueryBuilderCommon.java

### DIFF
--- a/src/main/java/multichain/command/builders/QueryBuilderCommon.java
+++ b/src/main/java/multichain/command/builders/QueryBuilderCommon.java
@@ -195,7 +195,11 @@ abstract class QueryBuilderCommon extends GsonFormatters {
 		CloseableHttpResponse response = httpclient.execute(httppost);
 		int statusCode = response.getStatusLine().getStatusCode();
 		if (statusCode >= 400) {
-			throw new MultichainException("code :" + statusCode, "message : " + response.getStatusLine().getReasonPhrase());
+			String message = "message : " + response.getStatusLine().getReasonPhrase();
+			// Close the response to prevent two exceptions from preventing future http requests
+			// As the default number of connections is 2. 
+			response.close();
+			throw new MultichainException("code :" + statusCode, message);
 		}
 		HttpEntity entity = response.getEntity();
 


### PR DESCRIPTION
executeRequest needs to close the request before throwing an exception. Otherwise there will be no open connections to use after two exceptions are thrown. I discovered this running the BlockCommandTest.java without changing the hash used for specific block retrieval. 
This comment helped me figure it out. https://stackoverflow.com/questions/33650157/httpclient-stop-executing-the-same-httpget-method-in-a-loop-after-executing-twic/33650384#33650384
  