### PR TITLE
Fixes issue #28 in which the Response Entity was not getting consumed…

### DIFF
--- a/src/main/java/multichain/command/builders/QueryBuilderCommon.java
+++ b/src/main/java/multichain/command/builders/QueryBuilderCommon.java
@@ -195,6 +195,7 @@ abstract class QueryBuilderCommon extends GsonFormatters {
 		CloseableHttpResponse response = httpclient.execute(httppost);
 		int statusCode = response.getStatusLine().getStatusCode();
 		if (statusCode >= 400) {
+			EntityUtils.consume(response.getEntity());
 			throw new MultichainException("code :" + statusCode, "message : " + response.getStatusLine().getReasonPhrase());
 		}
 		HttpEntity entity = response.getEntity();


### PR DESCRIPTION
… when there was an error, so the Pool would fill up and the library would sieze.