### PR TITLE
Implemented createFrom stream command and fixed bug with create permissions

### DIFF
--- a/src/multichain/command/StreamCommand.java
+++ b/src/multichain/command/StreamCommand.java
@@ -73,13 +73,71 @@ public class StreamCommand extends QueryBuilderStream {
 	 * Result: "transactionid" (string) The transaction id.
 	 * 
 	 * @param streamName
-	 * @param open
-	 *            = false
+	 * @param open = false
 	 * @return TxId
 	 * @throws MultichainException
 	 */
 	public String create(String streamName) throws MultichainException {
 		return create(streamName, false);
+	}
+
+	/**
+	 * create  stream "stream-name" from address open ( custom-fields )
+	 *
+	 * Creates stream
+	 *
+	 *
+	 * Arguments: 1. from address (string, required) From address the stream will
+	 * be created for 2. entity-type (string, required) The only possible value:
+	 * stream 3. "stream-name" (string, required) Stream name, if not "" should
+	 * be unique. 4. open (boolean, required) Allow anyone to publish in this
+	 * stream 5. custom-fields (object, optional) a json object with custom
+	 * fields { "param-name": "param-value" (strings, required) The key is the
+	 * parameter name, the value is parameter value ,... }
+	 *
+	 * Result: "transactionid" (string) The transaction id.
+	 *
+	 * @param fromAddress
+	 * @param streamName
+	 * @param open
+	 * @return TxId
+	 * @throws MultichainException
+	 */
+	public String createFrom(String fromAddress, String streamName, boolean open) throws MultichainException {
+		String stringCreate = "";
+
+		Object objectCreate = executeCreateFrom(fromAddress, streamName, open);
+		if (verifyInstance(objectCreate, String.class)) {
+			stringCreate = (String) objectCreate;
+		}
+
+		return stringCreate;
+	}
+
+	/**
+	 * create  stream "stream-name" from address open ( custom-fields )
+	 *
+	 * Creates stream
+	 *
+	 *
+	 * Arguments: 1. from address (string, required) From address the stream will
+	 * be created for 2. entity-type (string, required) The only possible value:
+	 * stream 3. "stream-name" (string, required) Stream name, if not "" should
+	 * be unique. 4. open (boolean, required) Allow anyone to publish in this
+	 * stream 5. custom-fields (object, optional) a json object with custom
+	 * fields { "param-name": "param-value" (strings, required) The key is the
+	 * parameter name, the value is parameter value ,... }
+	 *
+	 * Result: "transactionid" (string) The transaction id.
+	 *
+	 * @param fromAddress
+	 * @param streamName
+	 * @param open = false
+	 * @return TxId
+	 * @throws MultichainException
+	 */
+	public String createFrom(String fromAddress, String streamName) throws MultichainException {
+		return createFrom(fromAddress, streamName, false);
 	}
 
 	/**

--- a/src/multichain/command/builders/QueryBuilderGrant.java
+++ b/src/multichain/command/builders/QueryBuilderGrant.java
@@ -79,7 +79,7 @@ public class QueryBuilderGrant extends QueryBuilderCommon {
 			}
 			permissionsFormated = permissionsFormated.concat(ADMIN_STR);
 		}
-		if ((permissions & CREATE) > 0) {
+		if ((permissions & CREATE) < 0) {
 			if (permissionsFormated.length() > 0) {
 				permissionsFormated = permissionsFormated.concat(",");
 			}

--- a/src/multichain/command/builders/QueryBuilderStream.java
+++ b/src/multichain/command/builders/QueryBuilderStream.java
@@ -42,6 +42,35 @@ public class QueryBuilderStream extends QueryBuilderCommon {
 	}
 
 	/**
+	 * create from address stream "stream-name" open ( custom-fields )
+	 *
+	 * Creates stream from address
+	 *
+	 *
+	 * Arguments: 1. from address (string, required) From address the stream will
+	 * be created for 2. entity-type (string, required) The only possible value:
+	 * stream 3. "stream-name" (string, required) Stream name, if not "" should
+	 * be unique. 4. open (boolean, required) Allow anyone to publish in this
+	 * stream 5. custom-fields (object, optional) a json object with custom
+	 * fields { "param-name": "param-value" (strings, required) The key is the
+	 * parameter name, the value is parameter value ,... }
+	 *
+	 * Result: "transactionid" (string) The transaction id.
+	 *
+	 * @param fromAddress
+	 * @param streamName
+	 * @param open
+	 * @return TxId
+	 * @throws MultichainException
+	 */
+	protected Object executeCreateFrom(String fromAddress, String streamName, boolean open) throws MultichainException {
+		MultichainTestParameter.isNotNullOrEmpty("streamName", streamName);
+		MultichainTestParameter.isNotNullOrEmpty("fromAddress", fromAddress);
+
+		return execute(CommandEnum.CREATEFROM, fromAddress, "stream", streamName, open);
+	}
+
+	/**
 	 * 
 	 * liststreamkeys "stream-identifier" ( key(s) verbose count start local-ordering )
 	 * 

--- a/src/multichain/test/command/StreamCommandTest.java
+++ b/src/multichain/test/command/StreamCommandTest.java
@@ -25,6 +25,7 @@ public class StreamCommandTest {
 	static MultiChainCommand multiChainCommand;
 
 	static String streamName = "";
+	static String fromAddress ="1TLRjnPGioxA6iH1avFGcyS7PKS4dnWREhYbNE";
 
 	/**
 	 *
@@ -108,6 +109,24 @@ public class StreamCommandTest {
 		try {
 
 			result = multiChainCommand.getStreamCommand().create(streamName);
+		} catch (MultichainException e) {
+			// TODO Auto-generated catch block
+			e.printStackTrace();
+		}
+		if (result == null || "".equals(result)) {
+			System.err.println("testcreate - result is empty");
+		} else {
+			System.out.println("Result :");
+			System.out.println(result);
+		}
+	}
+
+	private static void testCreateFrom() {
+		String result = "";
+		System.out.println("testCreateFrom :");
+		try {
+
+			result = multiChainCommand.getStreamCommand().createFrom(fromAddress, streamName + "From");
 		} catch (MultichainException e) {
 			// TODO Auto-generated catch block
 			e.printStackTrace();
@@ -412,8 +431,8 @@ public class StreamCommandTest {
 		System.out.println("--- Start of StreamCommandTest ---");
 
 		// BlockChain TestCommand has to be created and started before
-		multiChainCommand = new MultiChainCommand("localhost", "6824", "multichainrpc",
-				"73oYQWzx45hossFPPWUgicpLvHhsD8PempYxnSF6bnY9");
+		multiChainCommand = new MultiChainCommand("localhost", "7434", "multichainrpc",
+				"2CHmxhzbvzM7qd2ryaPuuKqzpUvW9dExWb2ygPZPcr6o");
 
 		// BlockChain TestCommand has to be created and started before
 		// ChainCommand.initializeChain("TestAPI1");
@@ -430,6 +449,15 @@ public class StreamCommandTest {
 		System.out.println();
 
 		testcreate();
+
+		System.out.println();
+		System.out.println();
+		System.out.println();
+		System.out.println();
+		System.out.println();
+		System.out.println();
+
+		testCreateFrom();
 
 		System.out.println();
 		System.out.println();


### PR DESCRIPTION
I implemented the createFrom method as I needed to use it. I followed the same style and format of your code.
I also noticed a bug when implementing the create permission. If the create byte value is set, it still does not enter the if statement. So instead of checking if its greater than 0, I reverse the check and see if its less than 0. I tested this when adding multiple permissions and just the create permission on its own and verify it works.