### PR TITLE
Fixed objectBlockCount not getting casted to long

### DIFF
--- a/src/main/java/multichain/command/BlockCommand.java
+++ b/src/main/java/multichain/command/BlockCommand.java
@@ -204,6 +204,8 @@ public class BlockCommand extends QueryBuilderBlock {
 		Object objectBlockCount = executeGetBlockCount();
 		if (verifyInstance(objectBlockCount, long.class)) {
 			stringBlockCount = (long) objectBlockCount;
+		} else if (verifyInstance(objectBlockCount, Double.class)) {
+			stringBlockCount = ((Double)objectBlockCount).longValue();
 		}
 
 		return stringBlockCount;


### PR DESCRIPTION
`gson.fromJson(rpcAnswer, MultiChainRPCAnswer.class);`

It seems like gson is interpreting the result of getBlockCount as a double instead of long. This results in a failed instance type check. The blockcount stays zero which is incorrect.

I added a condition that casts the object to long whenever a double is returned. However, this will fail if gson returns an integer for example. I don't know if it would be better to catch all possible types or telling gson exactly what typ is expected.
