### PR TITLE
Implement listAssetTransactions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>com.multichainjavaapi</groupId>
 	<artifactId>MultiChainJavaAPI</artifactId>
-	<version>0.4.17-SNAPSHOT</version>
+	<version>0.4.18-SNAPSHOT</version>
 
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/src/main/java/multichain/command/WalletTransactionCommand.java
+++ b/src/main/java/multichain/command/WalletTransactionCommand.java
@@ -11,11 +11,13 @@ import java.util.ArrayList;
 import java.util.List;
 
 import multichain.command.builders.QueryBuilderWalletTransaction;
+import multichain.object.AssetTransaction;
 import multichain.object.BalanceAssetGeneral;
 import multichain.object.Transaction;
 import multichain.object.TransactionWallet;
 import multichain.object.TransactionWalletDetailed;
 import multichain.object.TxOut;
+import multichain.object.formatters.AssetTransactionFormatter;
 import multichain.object.formatters.TransactionFormatter;
 import multichain.object.formatters.TxOutFormatter;
 import multichain.object.formatters.WalletTransactionFormatter;
@@ -376,6 +378,76 @@ public class WalletTransactionCommand extends QueryBuilderWalletTransaction {
 	 */
 	public List<TransactionWallet> listAddressTransactions(String address) throws MultichainException {
 		return listAddressTransactionsWithoutDetail(address, 10, 0, false);
+	}
+
+  /**
+   * {@link #listAssetTransactions(String, boolean) with verbose at false}
+   * @param assetIdentifier
+   * @return
+   * @throws MultichainException
+   */
+  public List<AssetTransaction> listAssetTransactions(String assetIdentifier) throws MultichainException {
+    return listAssetTransactions(assetIdentifier, false, 10, 0, false);
+  }
+
+  /**
+   * {@link #listAssetTransactions(String, boolean, long)} with count at 10}
+   * @param assetIdentifier
+   * @return
+   * @throws MultichainException
+   */
+  public List<AssetTransaction> listAssetTransactions(String assetIdentifier, boolean verbose) throws MultichainException {
+    return listAssetTransactions(assetIdentifier, verbose, 10, 0, false);
+  }
+
+  /**
+   * {@link #listAssetTransactions(String, boolean, long, long, boolean)}  with start at 0 and localOrdering at false}
+   * @param assetIdentifier
+   * @return
+   * @throws MultichainException
+   */
+  public List<AssetTransaction> listAssetTransactions(String assetIdentifier, boolean verbose, long count) throws MultichainException {
+		return listAssetTransactions(assetIdentifier, verbose, count, 0, false);
+	}
+
+  /**
+   *
+   * lisassettransactions "asset-identifier" (verbose count start local-ordering)
+   *
+   * Returns up to 'count' most recent transactions skipping the first 'from'
+   * transactions for account 'account'.
+   *
+   * Arguments: 1. "address" (string, required) Address to list transactions
+   * for. 2. count (numeric, optional, default=10) The number of transactions
+   * to return 3. skip (numeric, optional, default=0) The number of
+   * transactions to skip 4. verbose (bool, optional, default=false) If true,
+   * returns detailed array of inputs and outputs and raw hex of transactions
+   *
+   * Lists transactions involving asset.
+   *
+   * Arguments:
+   * 1. "asset-identifier"               (string, required) Asset identifier - one of the following: asset txid, asset reference, asset name.
+   * 2. verbose                          (boolean, optional, default=false) If true, returns information about transaction
+   * 3. count                            (number, optional, default=10) The number of transactions to display
+   * 4. start                            (number, optional, default=-count - last) Start from specific transaction, 0 based, if negative - from the end
+   * 5. local-ordering                   (boolean, optional, default=false) If true, transactions appear in the order they were processed by the wallet,
+   *                                                                        if false - in the order they appear in blockchain
+   *
+   * Result:
+   * "stream-items"                      (array) List of transactions.
+   *
+   * @param assetIdentifier
+   * @param verbose
+   * @param count
+   * @param start
+   * @param localOrdering
+   * @return
+   * @throws MultichainException
+   */
+	public List<AssetTransaction> listAssetTransactions(String assetIdentifier, boolean verbose, long count, long start, boolean localOrdering) throws MultichainException {
+		Object objectAssetTransaction = executeListAssetTransactions(assetIdentifier, verbose, count, start, localOrdering);
+		List<AssetTransaction> listAssetTransaction = AssetTransactionFormatter.formatListAssetTransaction((List<Object>) objectAssetTransaction);
+		return listAssetTransaction;
 	}
 
 	/**

--- a/src/main/java/multichain/command/builders/QueryBuilderCommon.java
+++ b/src/main/java/multichain/command/builders/QueryBuilderCommon.java
@@ -101,6 +101,7 @@ abstract class QueryBuilderCommon extends GsonFormatters {
 								ISSUEMORE,
 								ISSUEMOREFROM,
 								LISTADDRESSTRANSACTIONS,
+								LISTASSETTRANSACTIONS,
 								LISTASSETS,
 								LISTLOCKUNPSENT,
 								LISTPERMISSIONS,

--- a/src/main/java/multichain/command/builders/QueryBuilderWalletTransaction.java
+++ b/src/main/java/multichain/command/builders/QueryBuilderWalletTransaction.java
@@ -257,6 +257,46 @@ public class QueryBuilderWalletTransaction extends QueryBuilderCommon {
 	}
 
 	/**
+	 *
+	 * lisassettransactions "asset-identifier" (verbose count start local-ordering)
+	 *
+	 * Returns up to 'count' most recent transactions skipping the first 'from'
+	 * transactions for account 'account'.
+	 *
+	 * Arguments: 1. "address" (string, required) Address to list transactions
+	 * for. 2. count (numeric, optional, default=10) The number of transactions
+	 * to return 3. skip (numeric, optional, default=0) The number of
+	 * transactions to skip 4. verbose (bool, optional, default=false) If true,
+	 * returns detailed array of inputs and outputs and raw hex of transactions
+	 *
+	 * Lists transactions involving asset.
+	 *
+	 * Arguments:
+	 * 1. "asset-identifier"               (string, required) Asset identifier - one of the following: asset txid, asset reference, asset name.
+	 * 2. verbose                          (boolean, optional, default=false) If true, returns information about transaction
+	 * 3. count                            (number, optional, default=10) The number of transactions to display
+	 * 4. start                            (number, optional, default=-count - last) Start from specific transaction, 0 based, if negative - from the end
+	 * 5. local-ordering                   (boolean, optional, default=false) If true, transactions appear in the order they were processed by the wallet,
+	 *                                                                        if false - in the order they appear in blockchain
+	 *
+	 * Result:
+	 * "stream-items"                      (array) List of transactions.
+	 *
+ 	 * @param assetIdentifier
+	 * @param verbose
+	 * @param count
+	 * @param start
+	 * @param localOrdering
+	 * @return
+	 * @throws MultichainException
+	 */
+	protected Object executeListAssetTransactions(String assetIdentifier, boolean verbose, long count, long start, boolean localOrdering) throws MultichainException {
+		MultichainTestParameter.isNotNullOrEmpty("assetIdentifier", assetIdentifier);
+		MultichainTestParameter.valueIsPositive("count", count);
+		return execute(CommandEnum.LISTASSETTRANSACTIONS, assetIdentifier, verbose, count, start, localOrdering);
+	}
+
+	/**
 	 * 
 	 * listwallettransactions ( count skip includeWatchonly verbose)
 	 * 

--- a/src/main/java/multichain/object/AssetTransaction.java
+++ b/src/main/java/multichain/object/AssetTransaction.java
@@ -1,0 +1,131 @@
+package multichain.object;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * @version 4.18
+ */
+public class AssetTransaction {
+
+	Map<String, Double> addresses;
+	List<Item> items;
+	List<String> data;
+	Long confirmations;
+	String blockhash;
+	Long blockindex;
+	Long blocktime;
+	String txid;
+	Boolean valid;
+	Long time;
+	Long timereceived;
+	List<TransactionWalletVin> vin;
+	List<TransactionWalletVout> vout;
+
+	public AssetTransaction() {
+	}
+
+	public Map<String, Double> getAddresses() {
+		return addresses;
+	}
+
+	public void setAddresses(Map<String, Double> addresses) {
+		this.addresses = addresses;
+	}
+
+	public List<Item> getItems() {
+		return items;
+	}
+
+	public void setItems(List<Item> items) {
+		this.items = items;
+	}
+
+	public List<String> getData() {
+		return data;
+	}
+
+	public void setData(List<String> data) {
+		this.data = data;
+	}
+
+	public Long getConfirmations() {
+		return confirmations;
+	}
+
+	public void setConfirmations(Long confirmations) {
+		this.confirmations = confirmations;
+	}
+
+	public String getBlockhash() {
+		return blockhash;
+	}
+
+	public void setBlockhash(String blockhash) {
+		this.blockhash = blockhash;
+	}
+
+	public Long getBlockindex() {
+		return blockindex;
+	}
+
+	public void setBlockindex(Long blockindex) {
+		this.blockindex = blockindex;
+	}
+
+	public Long getBlocktime() {
+		return blocktime;
+	}
+
+	public void setBlocktime(Long blocktime) {
+		this.blocktime = blocktime;
+	}
+
+	public String getTxid() {
+		return txid;
+	}
+
+	public void setTxid(String txid) {
+		this.txid = txid;
+	}
+
+	public Boolean getValid() {
+		return valid;
+	}
+
+	public void setValid(Boolean valid) {
+		this.valid = valid;
+	}
+
+	public Long getTime() {
+		return time;
+	}
+
+	public void setTime(Long time) {
+		this.time = time;
+	}
+
+	public Long getTimereceived() {
+		return timereceived;
+	}
+
+	public void setTimereceived(Long timereceived) {
+		this.timereceived = timereceived;
+	}
+
+	public List<TransactionWalletVin> getVin() {
+		return vin;
+	}
+
+	public void setVin(List<TransactionWalletVin> vin) {
+		this.vin = vin;
+	}
+
+	public List<TransactionWalletVout> getVout() {
+		return vout;
+	}
+
+	public void setVout(List<TransactionWalletVout> vout) {
+		this.vout = vout;
+	}
+}

--- a/src/main/java/multichain/object/formatters/AssetTransactionFormatter.java
+++ b/src/main/java/multichain/object/formatters/AssetTransactionFormatter.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (C) 2017 Worldline, Inc.
+ *
+ * MultiChainJavaAPI code distributed under the GPLv3 license, see COPYING file.
+ * https://github.com/SimplyUb/MultiChainJavaAPI/blob/master/LICENSE
+ *
+ */
+package multichain.object.formatters;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.internal.LinkedTreeMap;
+import java.util.ArrayList;
+import java.util.List;
+import multichain.object.AssetTransaction;
+
+/**
+ * @version 4.18
+ */
+public class AssetTransactionFormatter {
+	public final static List<AssetTransaction> formatListAssetTransaction(List<Object> objectAssetTransactions) {
+		List<AssetTransaction> assetTransactionList = new ArrayList<AssetTransaction>();
+		if (objectAssetTransactions != null) {
+			for (Object objectAssetTransaction : objectAssetTransactions) {
+				assetTransactionList.add(formatAssetTransaction(objectAssetTransaction));
+			}
+		}
+		return assetTransactionList;
+	}
+
+	public final static AssetTransaction formatAssetTransaction(Object objectAssetTransaction) {
+		AssetTransaction assetTransaction = new AssetTransaction();
+		if (objectAssetTransaction != null && LinkedTreeMap.class.isInstance(objectAssetTransaction)) {
+			GsonBuilder builder = new GsonBuilder();
+			Gson gson = builder.create();
+
+			String jsonValue = gson.toJson(objectAssetTransaction);
+			assetTransaction = gson.fromJson(jsonValue, AssetTransaction.class);
+		}
+		return assetTransaction;
+	}
+
+}


### PR DESCRIPTION
Create new object: AssetTransaction
Bump version from 4.17 to 4.18

I had to create a new object AssetTransaction because the output of listassettransactions is not the same as any of the already defined object