### PR TITLE
Resolved issue of null value from listaddresstransaction command output

### DIFF
--- a/src/main/java/multichain/object/TransactionWallet.java
+++ b/src/main/java/multichain/object/TransactionWallet.java
@@ -22,7 +22,7 @@ public class TransactionWallet {
   Create create = null;
   AssetWalletTransaction issue = null;
   List<Item> items = null;
-  List<String> data = null;
+  Object data = null;
   Long confirmations = null;
   String blockhash = null;
   Long blockindex = null;
@@ -47,7 +47,7 @@ public class TransactionWallet {
     addresses = new ArrayList<String>();
     permissions = new ArrayList<PermissionDetailed>();
     issue = null;
-    data = new ArrayList<String>();
+    data = new Object();
     items = new ArrayList<>();
 
   }
@@ -220,14 +220,14 @@ public class TransactionWallet {
   /**
    * @return the data
    */
-  public List<String> getData() {
+  public Object getData() {
     return data;
   }
 
   /**
    * @param data the data to set
    */
-  public void setData(List<String> data) {
+  public void setData(Object data) {
     this.data = data;
   }
 


### PR DESCRIPTION
When we add metadata with transaction and this metadata is in form of JSON then fetch it using getaddresstransaction command cause issues.
This command return null value for that specific transaction which contain json metadata.
Reason is simple, here we have data type of data attribute is list<string> and we trying to fetch json into that attribute from transaction.
Just simply converted it into object datatype and it works fine because, java object data type can handle any complex object stored in transaction's data attribute.